### PR TITLE
Update Makefile for kernel version compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ obj-m := $(TARGET).o
 default:
 	make -C $(KDIR) M=$(PWD) modules
 
+ifeq ($(shell [ $(shell uname -r | cut -d. -f1) -eq 6 ] && [ $(shell uname -r | cut -d. -f2) -lt 6 ] && echo yes),yes)
 $(TARGET).o: $(OBJS)
 	$(LD) $(LD_RFLAG) -r -o $@ $(OBJS)
+endif
 
 install:
 	su -c "cp -v $(TARGET).ko $(DEST) && /sbin/depmod -a"

--- a/VenusDrv.c
+++ b/VenusDrv.c
@@ -434,7 +434,7 @@ static int hfdu04_freebuffers(struct hfdu04_data *dev)
     return 0;
 }
 
-/* urb filling call back function for iso read  */
+/* usb filling call back function for iso read  */
 // #define EILSEQ          84      /* Illegal byte sequence */
 
 static void hfdu04_isocomplete(struct urb *purb, struct pt_regs *regs)


### PR DESCRIPTION
Added conditional linking in the Makefile to support kernels with major version 6 and minor version less than 6. Also fixed a typo in a comment in VenusDrv.c.